### PR TITLE
write to connection once

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Once a subscription has declared itself as a publisher, it will enter a loop whe
 
 ### Sending data via a connection
 
-When sending a message representing an action (subscribe, publish etc) then a uint8 binary message is sent. 
+When sending a message representing an action (subscribe, publish etc) then a uint16 binary message is sent. 
 
 When sending any other data, the length of the data is to be sent first using a binary uint32 and then the actual data sent afterwards. 

--- a/example/main.go
+++ b/example/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	for msg := range consumer.Messages() {
 		slog.Info("received message", "message", string(msg.Data))
+		msg.Ack(true)
 	}
 
 }


### PR DESCRIPTION
Instead of doing lots of binary.Writes to a connection, encode the data to binary and add to a byte slice and then write that byte slice once to the connection