### PR TITLE
persist messages to memory store and allow subscribers to start from x when starting

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -8,12 +8,15 @@ import (
 	"time"
 
 	"github.com/willdot/messagebroker/pubsub"
+	"github.com/willdot/messagebroker/server"
 )
 
 var consumeOnly *bool
+var consumeFrom *int
 
 func main() {
 	consumeOnly = flag.Bool("consume-only", false, "just consumes (doesn't start server and doesn't publish)")
+	consumeFrom = flag.Int("consume-from", -1, "index of message to start consuming from. If not set it will consume from the most recent")
 	flag.Parse()
 
 	if !*consumeOnly {
@@ -28,8 +31,14 @@ func main() {
 	defer func() {
 		_ = sub.Close()
 	}()
+	startAt := 0
+	startAtType := server.Current
+	if *consumeFrom >= 0-1 {
+		startAtType = server.From
+		startAt = *consumeFrom
+	}
 
-	err = sub.SubscribeToTopics([]string{"topic a"})
+	err = sub.SubscribeToTopics([]string{"topic a"}, startAtType, startAt)
 	if err != nil {
 		panic(err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ func main() {
 	}()
 	startAt := 0
 	startAtType := server.Current
-	if *consumeFrom >= 0-1 {
+	if *consumeFrom > -1 {
 		startAtType = server.From
 		startAt = *consumeFrom
 	}

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	srv, err := server.New(":3000", time.Second, time.Second*2, server.NewMemoryStore())
+	srv, err := server.New(":3000", time.Second, time.Second*2)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	srv, err := server.New(":3000", time.Second, time.Second*2)
+	srv, err := server.New(":3000", time.Second, time.Second*2, server.NewMemoryStore())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pubsub/subscriber_test.go
+++ b/pubsub/subscriber_test.go
@@ -18,19 +18,8 @@ const (
 	topicB     = "topic b"
 )
 
-type fakeStore struct {
-}
-
-func (f *fakeStore) Write(msg server.MessageToSend) error {
-	return nil
-}
-func (f *fakeStore) ReadFrom(offset int, handleFunc func(msgs []server.MessageToSend)) error {
-	return nil
-}
-
 func createServer(t *testing.T) {
-	fs := &fakeStore{}
-	server, err := server.New(serverAddr, time.Millisecond*100, time.Millisecond*100, fs)
+	server, err := server.New(serverAddr, time.Millisecond*100, time.Millisecond*100)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pubsub/subscriber_test.go
+++ b/pubsub/subscriber_test.go
@@ -18,8 +18,19 @@ const (
 	topicB     = "topic b"
 )
 
+type fakeStore struct {
+}
+
+func (f *fakeStore) Write(msg server.MessageToSend) error {
+	return nil
+}
+func (f *fakeStore) ReadFrom(offset int, handleFunc func(msgs []server.MessageToSend)) error {
+	return nil
+}
+
 func createServer(t *testing.T) {
-	server, err := server.New(serverAddr, time.Millisecond*100, time.Millisecond*100)
+	fs := &fakeStore{}
+	server, err := server.New(serverAddr, time.Millisecond*100, time.Millisecond*100, fs)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -75,7 +86,7 @@ func TestSubscribeToTopics(t *testing.T) {
 
 	topics := []string{topicA, topicB}
 
-	err = sub.SubscribeToTopics(topics)
+	err = sub.SubscribeToTopics(topics, server.Current, 0)
 	require.NoError(t, err)
 }
 
@@ -91,7 +102,7 @@ func TestUnsubscribesFromTopic(t *testing.T) {
 
 	topics := []string{topicA, topicB}
 
-	err = sub.SubscribeToTopics(topics)
+	err = sub.SubscribeToTopics(topics, server.Current, 0)
 	require.NoError(t, err)
 
 	err = sub.UnsubscribeToTopics([]string{topicA})
@@ -258,7 +269,7 @@ func setupConsumer(t *testing.T) (*Consumer, context.CancelFunc) {
 
 	topics := []string{topicA, topicB}
 
-	err = sub.SubscribeToTopics(topics)
+	err = sub.SubscribeToTopics(topics, server.Current, 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/message_store.go
+++ b/server/message_store.go
@@ -5,18 +5,21 @@ import (
 	"sync"
 )
 
+// Memory store allows messages to be stored in memory
 type MemoryStore struct {
 	mu     sync.Mutex
 	msgs   map[int]message
 	offset int
 }
 
+// New memory store initializes a new in memory store
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
 		msgs: make(map[int]message),
 	}
 }
 
+// Write will write the provided message to the in memory store
 func (m *MemoryStore) Write(msg message) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -28,6 +31,7 @@ func (m *MemoryStore) Write(msg message) error {
 	return nil
 }
 
+// ReadFrom will read messages from (and including) the provided offset and pass them to the provided handler
 func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msg message)) error {
 	if offset < 0 || offset > m.offset {
 		return fmt.Errorf("invalid offset provided")

--- a/server/message_store.go
+++ b/server/message_store.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+)
+
+type MemoryStore struct {
+	mu     sync.Mutex
+	msgs   map[int]MessageToSend
+	offset int
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		msgs: make(map[int]MessageToSend),
+	}
+}
+
+func (m *MemoryStore) Write(msg MessageToSend) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.msgs[m.offset] = msg
+
+	m.offset++
+
+	return nil
+}
+
+func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msgs []MessageToSend)) error {
+	if offset < 0 || offset > m.offset {
+		return fmt.Errorf("invalid offset provided")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	msgs := make([]MessageToSend, 0, len(m.msgs))
+	for i := offset; i < len(m.msgs); i++ {
+		msgs = append(msgs, m.msgs[i])
+	}
+
+	handleFunc(msgs)
+
+	return nil
+}

--- a/server/message_store.go
+++ b/server/message_store.go
@@ -28,7 +28,7 @@ func (m *MemoryStore) Write(msg MessageToSend) error {
 	return nil
 }
 
-func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msgs []MessageToSend)) error {
+func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msg MessageToSend)) error {
 	if offset < 0 || offset > m.offset {
 		return fmt.Errorf("invalid offset provided")
 	}
@@ -36,12 +36,9 @@ func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msgs []MessageToSend)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	msgs := make([]MessageToSend, 0, len(m.msgs))
 	for i := offset; i < len(m.msgs); i++ {
-		msgs = append(msgs, m.msgs[i])
+		handleFunc(m.msgs[i])
 	}
-
-	handleFunc(msgs)
 
 	return nil
 }

--- a/server/message_store.go
+++ b/server/message_store.go
@@ -7,17 +7,17 @@ import (
 
 type MemoryStore struct {
 	mu     sync.Mutex
-	msgs   map[int]MessageToSend
+	msgs   map[int]message
 	offset int
 }
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		msgs: make(map[int]MessageToSend),
+		msgs: make(map[int]message),
 	}
 }
 
-func (m *MemoryStore) Write(msg MessageToSend) error {
+func (m *MemoryStore) Write(msg message) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -28,7 +28,7 @@ func (m *MemoryStore) Write(msg MessageToSend) error {
 	return nil
 }
 
-func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msg MessageToSend)) error {
+func (m *MemoryStore) ReadFrom(offset int, handleFunc func(msg message)) error {
 	if offset < 0 || offset > m.offset {
 		return fmt.Errorf("invalid offset provided")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -302,11 +302,6 @@ func (s *Server) handleUnsubscribe(peer *peer.Peer) {
 	_ = peer.RunConnOperation(op)
 }
 
-type MessageToSend struct {
-	topic string
-	data  []byte
-}
-
 func (s *Server) handlePublish(peer *peer.Peer) {
 	slog.Info("handling publisher", "peer", peer.Addr())
 	for {
@@ -357,16 +352,13 @@ func (s *Server) handlePublish(peer *peer.Peer) {
 				return nil
 			}
 
-			message := MessageToSend{
-				topic: topicStr,
-				data:  dataBuf,
+			topic := s.getTopic(topicStr)
+			if topic == nil {
+				topic = newTopic(topicStr)
+				s.topics[topicStr] = topic
 			}
 
-			topic := s.getTopic(message.topic)
-			if topic == nil {
-				topic = newTopic(message.topic)
-				s.topics[message.topic] = topic
-			}
+			message := newMessage(dataBuf)
 
 			err = topic.sendMessageToSubscribers(message)
 			if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -27,23 +27,6 @@ const (
 	Nack        Action = 5
 )
 
-func (a Action) String() string {
-	switch a {
-	case Subscribe:
-		return "subscribe"
-	case Unsubscribe:
-		return "unsubscribe"
-	case Publish:
-		return "publish"
-	case Ack:
-		return "ack"
-	case Nack:
-		return "nack"
-	}
-
-	return ""
-}
-
 // Status represents the status of a request
 type Status uint16
 
@@ -70,9 +53,9 @@ func (s Status) String() string {
 type StartAtType uint16
 
 const (
-	Begining StartAtType = 0
-	Current  StartAtType = 1
-	From     StartAtType = 2
+	Beginning StartAtType = 0
+	Current   StartAtType = 1
+	From      StartAtType = 2
 )
 
 // Server accepts subscribe and publish connections and passes messages around
@@ -234,7 +217,6 @@ func (s *Server) subscribePeerToTopic(peer *peer.Peer) {
 		var startAt int
 		switch startAtType {
 		case From:
-			// read the from
 			var s uint16
 			err = binary.Read(conn, binary.BigEndian, &s)
 			if err != nil {
@@ -243,7 +225,7 @@ func (s *Server) subscribePeerToTopic(peer *peer.Peer) {
 				return nil
 			}
 			startAt = int(s)
-		case Begining:
+		case Beginning:
 			startAt = 0
 		case Current:
 			startAt = -1

--- a/server/server.go
+++ b/server/server.go
@@ -27,13 +27,30 @@ const (
 	Nack        Action = 5
 )
 
+func (a Action) String() string {
+	switch a {
+	case Subscribe:
+		return "subscribe"
+	case Unsubscribe:
+		return "unsubscribe"
+	case Publish:
+		return "publish"
+	case Ack:
+		return "ack"
+	case Nack:
+		return "nack"
+	}
+
+	return ""
+}
+
 // Status represents the status of a request
 type Status uint16
 
 const (
-	Subscribed   = 1
-	Unsubscribed = 2
-	Error        = 3
+	Subscribed   Status = 1
+	Unsubscribed Status = 2
+	Error        Status = 3
 )
 
 func (s Status) String() string {
@@ -49,6 +66,20 @@ func (s Status) String() string {
 	return ""
 }
 
+// StartAtType represents where the subcriber wishes to start subscribing to a topic from
+type StartAtType uint16
+
+const (
+	Begining StartAtType = 0
+	Current  StartAtType = 1
+	From     StartAtType = 2
+)
+
+type Store interface {
+	Write(msg MessageToSend) error
+	ReadFrom(offset int, handleFunc func(msgs []MessageToSend)) error
+}
+
 // Server accepts subscribe and publish connections and passes messages around
 type Server struct {
 	Addr string
@@ -59,20 +90,23 @@ type Server struct {
 
 	ackDelay   time.Duration
 	ackTimeout time.Duration
+
+	messageStore Store
 }
 
 // New creates and starts a new server
-func New(Addr string, ackDelay, ackTimeout time.Duration) (*Server, error) {
+func New(Addr string, ackDelay, ackTimeout time.Duration, messageStore Store) (*Server, error) {
 	lis, err := net.Listen("tcp", Addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen: %w", err)
 	}
 
 	srv := &Server{
-		lis:        lis,
-		topics:     map[string]*topic{},
-		ackDelay:   ackDelay,
-		ackTimeout: ackTimeout,
+		lis:          lis,
+		topics:       map[string]*topic{},
+		ackDelay:     ackDelay,
+		ackTimeout:   ackTimeout,
+		messageStore: messageStore,
 	}
 
 	go srv.start()
@@ -191,6 +225,7 @@ func (s *Server) subscribePeerToTopic(peer *peer.Peer) {
 		}
 
 		var topics []string
+		fmt.Println(string(buf))
 		err = json.Unmarshal(buf, &topics)
 		if err != nil {
 			slog.Error("failed to unmarshal subscibers topic data", "error", err, "peer", peer.Addr())
@@ -198,7 +233,36 @@ func (s *Server) subscribePeerToTopic(peer *peer.Peer) {
 			return nil
 		}
 
-		s.subscribeToTopics(peer, topics)
+		var startAtType StartAtType
+		err = binary.Read(conn, binary.BigEndian, &startAtType)
+		if err != nil {
+			slog.Error(err.Error(), "peer", peer.Addr())
+			writeStatus(Error, "invalid start at type provided", conn)
+			return nil
+		}
+		var startAt int
+		switch startAtType {
+		case From:
+			// read the from
+			var s uint16
+			err = binary.Read(conn, binary.BigEndian, &s)
+			if err != nil {
+				slog.Error(err.Error(), "peer", peer.Addr())
+				writeStatus(Error, "invalid start at value provided", conn)
+				return nil
+			}
+			startAt = int(s)
+		case Begining:
+			startAt = 0
+		case Current:
+			startAt = -1
+		default:
+			slog.Error("invalid start up type provided", "start up type", startAtType)
+			writeStatus(Error, "invalid start up type provided", conn)
+			return nil
+		}
+
+		s.subscribeToTopics(peer, topics, startAt)
 		writeStatus(Subscribed, "", conn)
 
 		return nil
@@ -247,7 +311,7 @@ func (s *Server) handleUnsubscribe(peer *peer.Peer) {
 	_ = peer.RunConnOperation(op)
 }
 
-type messageToSend struct {
+type MessageToSend struct {
 	topic string
 	data  []byte
 }
@@ -255,7 +319,7 @@ type messageToSend struct {
 func (s *Server) handlePublish(peer *peer.Peer) {
 	slog.Info("handling publisher", "peer", peer.Addr())
 	for {
-		var message *messageToSend
+		var message *MessageToSend
 
 		op := func(conn net.Conn) error {
 			dataLen, err := dataLength(conn)
@@ -304,47 +368,48 @@ func (s *Server) handlePublish(peer *peer.Peer) {
 				return nil
 			}
 
-			message = &messageToSend{
+			message = &MessageToSend{
 				topic: topicStr,
 				data:  dataBuf,
 			}
+
+			topic := s.getTopic(message.topic)
+			if topic == nil {
+				topic = newTopic(message.topic, s.messageStore)
+				s.topics[message.topic] = topic
+			}
+
+			err = topic.sendMessageToSubscribers(*message)
+			if err != nil {
+				slog.Error("failed to send message to subscribers", "error", err, "peer", peer.Addr())
+				writeStatus(Error, "failed to send message to subscribers", conn)
+				return nil
+			}
+
 			return nil
 		}
 
 		_ = peer.RunConnOperation(op)
-
-		if message == nil {
-			continue
-		}
-
-		// sending messages to the subscribers can be done async because the publisher doesn't need to wait for
-		// subscribers to be sent the message
-		go func() {
-			topic := s.getTopic(message.topic)
-			if topic != nil {
-				topic.sendMessageToSubscribers(message.data)
-			}
-		}()
 	}
 }
 
-func (s *Server) subscribeToTopics(peer *peer.Peer, topics []string) {
+func (s *Server) subscribeToTopics(peer *peer.Peer, topics []string, startAt int) {
 	slog.Info("subscribing peer to topics", "topics", topics, "peer", peer.Addr())
 	for _, topic := range topics {
-		s.addSubsciberToTopic(topic, peer)
+		s.addSubsciberToTopic(topic, peer, startAt)
 	}
 }
 
-func (s *Server) addSubsciberToTopic(topicName string, peer *peer.Peer) {
+func (s *Server) addSubsciberToTopic(topicName string, peer *peer.Peer, startAt int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	t, ok := s.topics[topicName]
 	if !ok {
-		t = newTopic(topicName)
+		t = newTopic(topicName, s.messageStore)
 	}
 
-	t.subscriptions[peer.Addr()] = newSubscriber(peer, topicName, s.ackDelay, s.ackTimeout)
+	t.subscriptions[peer.Addr()] = newSubscriber(peer, topicName, s.ackDelay, s.ackTimeout, s.messageStore, startAt)
 
 	s.topics[topicName] = t
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -183,6 +183,10 @@ func TestSubscriberClosesWithoutUnsubscribing(t *testing.T) {
 
 	sendMessage(t, publisherConn, topicA, data)
 
+	// the timeout for a connection is 100 milliseconds, so we should wait at least this long before checking the unsubscribe
+	// TODO: see if theres a better way, but without this, the test is flakey
+	time.Sleep(time.Millisecond * 100)
+
 	assert.Len(t, srv.topics, 2)
 	assert.Len(t, srv.topics[topicA].subscriptions, 0)
 	assert.Len(t, srv.topics[topicB].subscriptions, 0)

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -44,6 +44,10 @@ func newSubscriber(peer *peer.Peer, topic *topic, ackDelay, ackTimeout time.Dura
 	offset := startAt
 
 	go func() {
+		if startAt < 0 {
+			return
+		}
+
 		err := topic.messageStore.ReadFrom(offset, func(msg message) {
 			s.messages <- msg
 		})

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -44,8 +44,8 @@ func newSubscriber(peer *peer.Peer, topic *topic, ackDelay, ackTimeout time.Dura
 	offset := startAt
 
 	go func() {
-		err := topic.messageStore.ReadFrom(offset, func(msg MessageToSend) {
-			s.messages <- newMessage(msg.data)
+		err := topic.messageStore.ReadFrom(offset, func(msg message) {
+			s.messages <- msg
 		})
 		if err != nil {
 			slog.Error("failed to replay messages from offset", "error", err, "offset", offset)

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -44,13 +44,8 @@ func newSubscriber(peer *peer.Peer, topic string, ackDelay, ackTimeout time.Dura
 	offset := startAt
 
 	go func() {
-		// here we need to replay all messages from the store for the topic.
-		err := messageStore.ReadFrom(offset, func(msgs []MessageToSend) {
-			// go func() {
-			for _, msg := range msgs {
-				s.messages <- newMessage(msg.data)
-			}
-			// }()
+		err := messageStore.ReadFrom(offset, func(msg MessageToSend) {
+			s.messages <- newMessage(msg.data)
 		})
 		if err != nil {
 			slog.Error("failed to replay messages from offset", "error", err, "offset", offset)

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -29,10 +29,10 @@ func newMessage(data []byte) message {
 	return message{data: data, deliveryCount: 1}
 }
 
-func newSubscriber(peer *peer.Peer, topic string, ackDelay, ackTimeout time.Duration, messageStore Store, startAt int) *subscriber {
+func newSubscriber(peer *peer.Peer, topic *topic, ackDelay, ackTimeout time.Duration, startAt int) *subscriber {
 	s := &subscriber{
 		peer:          peer,
-		topic:         topic,
+		topic:         topic.name,
 		messages:      make(chan message),
 		ackDelay:      ackDelay,
 		ackTimeout:    ackTimeout,
@@ -44,7 +44,7 @@ func newSubscriber(peer *peer.Peer, topic string, ackDelay, ackTimeout time.Dura
 	offset := startAt
 
 	go func() {
-		err := messageStore.ReadFrom(offset, func(msg MessageToSend) {
+		err := topic.messageStore.ReadFrom(offset, func(msg MessageToSend) {
 			s.messages <- newMessage(msg.data)
 		})
 		if err != nil {

--- a/server/topic.go
+++ b/server/topic.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Store interface {
-	Write(msg MessageToSend) error
-	ReadFrom(offset int, handleFunc func(msg MessageToSend)) error
+	Write(msg message) error
+	ReadFrom(offset int, handleFunc func(msg message)) error
 }
 
 type topic struct {
@@ -27,7 +27,7 @@ func newTopic(name string) *topic {
 	}
 }
 
-func (t *topic) sendMessageToSubscribers(msg MessageToSend) error {
+func (t *topic) sendMessageToSubscribers(msg message) error {
 	err := t.messageStore.Write(msg)
 	if err != nil {
 		return fmt.Errorf("failed to write message to store: %w", err)
@@ -38,7 +38,7 @@ func (t *topic) sendMessageToSubscribers(msg MessageToSend) error {
 	t.mu.Unlock()
 
 	for _, subscriber := range subscribers {
-		subscriber.addMessage(newMessage(msg.data), 0)
+		subscriber.addMessage(msg, 0)
 	}
 
 	return nil

--- a/server/topic.go
+++ b/server/topic.go
@@ -6,6 +6,11 @@ import (
 	"sync"
 )
 
+type Store interface {
+	Write(msg MessageToSend) error
+	ReadFrom(offset int, handleFunc func(msg MessageToSend)) error
+}
+
 type topic struct {
 	name          string
 	subscriptions map[net.Addr]*subscriber

--- a/server/topic.go
+++ b/server/topic.go
@@ -8,7 +8,7 @@ import (
 
 type Store interface {
 	Write(msg message) error
-	ReadFrom(offset int, handleFunc func(msg message)) error
+	ReadFrom(offset int, handleFunc func(msg message))
 }
 
 type topic struct {

--- a/server/topic.go
+++ b/server/topic.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net"
 	"sync"
 )
@@ -9,21 +10,30 @@ type topic struct {
 	name          string
 	subscriptions map[net.Addr]*subscriber
 	mu            sync.Mutex
+	messageStore  Store
 }
 
-func newTopic(name string) *topic {
+func newTopic(name string, messageStore Store) *topic {
 	return &topic{
 		name:          name,
 		subscriptions: make(map[net.Addr]*subscriber),
+		messageStore:  messageStore,
 	}
 }
 
-func (t *topic) sendMessageToSubscribers(msgData []byte) {
+func (t *topic) sendMessageToSubscribers(msg MessageToSend) error {
+	err := t.messageStore.Write(msg)
+	if err != nil {
+		return fmt.Errorf("failed to write message to store: %w", err)
+	}
+
 	t.mu.Lock()
 	subscribers := t.subscriptions
 	t.mu.Unlock()
 
 	for _, subscriber := range subscribers {
-		subscriber.addMessage(newMessage(msgData), 0)
+		subscriber.addMessage(newMessage(msg.data), 0)
 	}
+
+	return nil
 }

--- a/server/topic.go
+++ b/server/topic.go
@@ -13,7 +13,8 @@ type topic struct {
 	messageStore  Store
 }
 
-func newTopic(name string, messageStore Store) *topic {
+func newTopic(name string) *topic {
+	messageStore := NewMemoryStore()
 	return &topic{
 		name:          name,
 		subscriptions: make(map[net.Addr]*subscriber),


### PR DESCRIPTION
This allows messages to be stored in memory for each topic so that when subscribers start to subscribe, they can chose to start consuming at the beginning, current or a selected index of messages.